### PR TITLE
Add Polish versions for main and frontend README files

### DIFF
--- a/README.pl.md
+++ b/README.pl.md
@@ -1,0 +1,51 @@
+# Mayournaise
+
+## Programowanie
+
+Po utworzeniu projektu i zainstalowaniu zależności za pomocą `npm install` (lub `pnpm install` lub `yarn`), uruchom serwer deweloperski:
+
+```bash
+npm run dev
+
+# lub uruchom serwer i otwórz aplikację w nowej karcie przeglądarki
+npm run dev -- --open
+```
+
+## Budowanie
+
+Aby utworzyć wersję produkcyjną aplikacji:
+
+```bash
+npm run build
+```
+
+Możesz podejrzeć wersję produkcyjną za pomocą `npm run preview`.
+
+## Lambda
+
+Zainstaluj cargo lambda za pomocą `curl -fsSL https://cargo-lambda.info/install.sh | sh`
+
+cargo lambda build --arm64 --release
+cargo lambda deploy --enable-function-url mayournaise --profile personal
+
+
+URL funkcji: https://eo2rkpwkcqr36lclwmighanldm0xuzpx.lambda-url.eu-west-1.on.aws/
+
+Operacje konfiguracyjne:
+ - dodaj CORS do URL funkcji
+ - zezwól na nagłówek content-type
+ - zezwól funkcji Lambda na dostęp do DynamoDB
+
+
+## Frontend
+
+Przejdź do katalogu frontend
+Uruchom `vercel --prod`
+
+## Do zrobienia
+- monitoring wykorzystania funkcji Lambda
+- dodanie prawdziwego mechanizmu kodów polecających
+- przycisk losowania opcji
+- dodanie możliwości dodawania dodatków, takich jak czosnek, dym, harissa itp.
+- limit zamówień na adres e-mail?
+- upiększenie frontendu

--- a/frontend/README.pl.md
+++ b/frontend/README.pl.md
@@ -1,0 +1,50 @@
+# React + TypeScript + Vite
+
+Ten szablon zapewnia minimalne ustawienia, aby React działał w Vite z HMR i niektórymi regułami ESLint.
+
+Obecnie dostępne są dwie oficjalne wtyczki:
+
+- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) używa [Babel](https://babeljs.io/) dla Fast Refresh
+- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) używa [SWC](https://swc.rs/) dla Fast Refresh
+
+## Rozszerzanie konfiguracji ESLint
+
+Jeśli tworzysz aplikację produkcyjną, zalecamy zaktualizowanie konfiguracji, aby włączyć reguły lint świadome typów:
+
+- Skonfiguruj właściwość `parserOptions` najwyższego poziomu w następujący sposób:
+
+```js
+export default tseslint.config({
+  languageOptions: {
+    // inne opcje...
+    parserOptions: {
+      project: ['./tsconfig.node.json', './tsconfig.app.json'],
+      tsconfigRootDir: import.meta.dirname,
+    },
+  },
+})
+```
+
+- Zamień `tseslint.configs.recommended` na `tseslint.configs.recommendedTypeChecked` lub `tseslint.configs.strictTypeChecked`
+- Opcjonalnie dodaj `...tseslint.configs.stylisticTypeChecked`
+- Zainstaluj [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) i zaktualizuj konfigurację:
+
+```js
+// eslint.config.js
+import react from 'eslint-plugin-react'
+
+export default tseslint.config({
+  // Ustaw wersję react
+  settings: { react: { version: '18.3' } },
+  plugins: {
+    // Dodaj wtyczkę react
+    react,
+  },
+  rules: {
+    // inne reguły...
+    // Włącz zalecane reguły
+    ...react.configs.recommended.rules,
+    ...react.configs['jsx-runtime'].rules,
+  },
+})
+```


### PR DESCRIPTION
### Summary
This PR introduces Polish translations for the main project and frontend README files, making project documentation accessible for Polish-speaking contributors.

### Details
- Added `README.pl.md` with Polish content in the root directory.
- Added `README.pl.md` with Polish content to the `frontend` directory.
- Preserved code blocks, structure, and all technical instructions from the original English versions.

Warning: Engine could not check its work as expected due to a missing or failing Task VM test. Engine will perform much better if you complete and test the setup.